### PR TITLE
support modifying python lib deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "nix-editor"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nix-editor"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/verify_getter.rs
+++ b/src/verify_getter.rs
@@ -1,0 +1,196 @@
+use anyhow::{bail, Result};
+use rnix::*;
+
+use crate::DepType;
+
+// kind of like assert! but returns an error instead of panicking
+macro_rules! verify_eq {
+    ($a:expr, $b:expr) => {
+        if $a != $b {
+            bail!(
+                "error: expected {} but got {}",
+                stringify!($b),
+                stringify!($a)
+            );
+        }
+    };
+}
+
+macro_rules! unwrap_or_return {
+    ($e:expr) => {
+        match $e {
+            Some(e) => e,
+            None => bail!("error: expected some"),
+        }
+    };
+}
+
+// Will try to parse through the AST and return a list of deps
+// If at any point, the tree is not *exactly* how we expect it to look,
+// it will return an error. Since nix is so complex, we have to require some
+// assumptions about the AST, or else it'll be impossible to do anything.
+pub fn verify_get(root: SyntaxNode, dep_type: DepType) -> Result<SyntaxNode> {
+    verify_eq!(root.kind(), SyntaxKind::NODE_ROOT);
+
+    let lambda = unwrap_or_return!(get_nth_child(&root, 0));
+    verify_eq!(lambda.kind(), SyntaxKind::NODE_LAMBDA);
+
+    let arg_pattern = unwrap_or_return!(get_nth_child(&lambda, 0));
+    verify_eq!(arg_pattern.kind(), SyntaxKind::NODE_PATTERN);
+
+    if find_child_with_value(&arg_pattern, "pkgs").is_none() {
+        bail!("error: expected pkgs");
+    }
+
+    let attr_set = unwrap_or_return!(get_nth_child(&lambda, 1));
+    verify_eq!(attr_set.kind(), SyntaxKind::NODE_ATTR_SET);
+
+    let deps_list = match dep_type {
+        DepType::Regular => verify_get_regular(attr_set)?,
+        DepType::Python => verify_get_python(attr_set)?,
+    };
+
+    Ok(deps_list)
+}
+
+fn verify_get_regular(attr_set: SyntaxNode) -> Result<SyntaxNode> {
+    let deps = unwrap_or_return!(find_key_value_with_key(&attr_set, "deps"));
+    verify_eq!(deps.kind(), SyntaxKind::NODE_KEY_VALUE);
+
+    let deps_list = unwrap_or_return!(get_nth_child(&deps, 1));
+    verify_eq!(deps_list.kind(), SyntaxKind::NODE_LIST);
+
+    Ok(deps_list)
+}
+
+fn verify_get_python(attr_set: SyntaxNode) -> Result<SyntaxNode> {
+    let env = unwrap_or_return!(find_key_value_with_key(&attr_set, "env"));
+    verify_eq!(env.kind(), SyntaxKind::NODE_KEY_VALUE);
+
+    let env_attr_set = unwrap_or_return!(get_nth_child(&env, 1));
+    verify_eq!(env_attr_set.kind(), SyntaxKind::NODE_ATTR_SET);
+
+    let py_lib_path = unwrap_or_return!(find_key_value_with_key(
+        &env_attr_set,
+        "PYTHON_LD_LIBRARY_PATH"
+    ));
+    verify_eq!(py_lib_path.kind(), SyntaxKind::NODE_KEY_VALUE);
+
+    let py_lib_apply = unwrap_or_return!(get_nth_child(&py_lib_path, 1));
+    verify_eq!(py_lib_apply.kind(), SyntaxKind::NODE_APPLY);
+
+    let py_lib_node_select = unwrap_or_return!(get_nth_child(&py_lib_apply, 0));
+    verify_eq!(py_lib_node_select.kind(), SyntaxKind::NODE_SELECT);
+    verify_eq!(py_lib_node_select.text(), "pkgs.lib.makeLibraryPath");
+
+    let py_lib_node_list = unwrap_or_return!(get_nth_child(&py_lib_apply, 1));
+    verify_eq!(py_lib_node_list.kind(), SyntaxKind::NODE_LIST);
+
+    Ok(py_lib_node_list)
+}
+
+fn get_nth_child(node: &SyntaxNode, index: usize) -> Option<SyntaxNode> {
+    node.children().into_iter().nth(index)
+}
+
+fn find_child_with_value(node: &SyntaxNode, name: &str) -> Option<SyntaxNode> {
+    node.children()
+        .into_iter()
+        .find(|child| child.text() == name)
+}
+
+fn find_key_value_with_key(node: &SyntaxNode, key: &str) -> Option<SyntaxNode> {
+    if node.kind() != SyntaxKind::NODE_ATTR_SET {
+        return None;
+    }
+
+    node.children().into_iter().find(|child| {
+        if child.kind() != SyntaxKind::NODE_KEY_VALUE {
+            return false;
+        }
+
+        let key_node = match get_nth_child(child, 0) {
+            Some(child) => child,
+            None => return false,
+        };
+
+        key_node.text() == key
+    })
+}
+
+// unit tests
+#[cfg(test)]
+mod verify_get_tests {
+    use super::*;
+    use rnix::parse;
+
+    fn python_replit_nix_ast() -> SyntaxNode {
+        let code = r#"
+{ pkgs }: {
+  deps = [
+    pkgs.python38Full
+  ];
+  env = {
+    PYTHON_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+      # Needed for pandas / numpy
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+      # Needed for pygame
+      pkgs.glib
+      # Needed for matplotlib
+      pkgs.xorg.libX11
+    ];
+    PYTHONBIN = "${pkgs.python38Full}/bin/python3.8";
+    LANG = "en_US.UTF-8";
+  };
+}
+        "#;
+        parse(code).node()
+    }
+
+    #[test]
+    fn verify_get_python() {
+        let ast = python_replit_nix_ast();
+        let deps_list_res = verify_get(ast, DepType::Python);
+
+        assert!(deps_list_res.is_ok());
+
+        let deps_list = deps_list_res.unwrap();
+        let deps_list_children: Vec<SyntaxNode> = deps_list.children().collect();
+
+        assert_eq!(deps_list_children.len(), 4);
+
+        let deps_list_children_names = deps_list_children
+            .iter()
+            .map(|child| child.text())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            deps_list_children_names,
+            vec![
+                "pkgs.stdenv.cc.cc.lib",
+                "pkgs.zlib",
+                "pkgs.glib",
+                "pkgs.xorg.libX11"
+            ]
+        );
+
+        for child in deps_list_children {
+            assert_eq!(child.kind(), SyntaxKind::NODE_SELECT);
+        }
+    }
+
+    #[test]
+    fn verify_get_regular() {
+        let ast = python_replit_nix_ast();
+        let deps_list_res = verify_get(ast, DepType::Regular);
+
+        assert!(deps_list_res.is_ok());
+
+        let deps_list = deps_list_res.unwrap();
+        let deps_list_children: Vec<SyntaxNode> = deps_list.children().collect();
+
+        assert_eq!(deps_list_children.len(), 1);
+        assert_eq!(deps_list_children[0].text(), "pkgs.python38Full");
+        assert_eq!(deps_list_children[0].kind(), SyntaxKind::NODE_SELECT);
+    }
+}


### PR DESCRIPTION
In python repls, we sometimes need to update or modify python library pkgs. These are still stored in the replit.nix, but stored separately from the other dependancies. And so, we need a new way to be able to modify them. 

Here, I have updated the code for navigating the AST and finding the dependancy array. I have added an additional flag that allows me to switch between getting the two dep arrays. The flag can be optionally passed in by users to modify the python array. If it is not passed in, it will default to the original way.