### PR TITLE
nix: remove flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1657561094,
@@ -33,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,25 +1,28 @@
 {
   description = "A replit.nix editor.";
 
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          nix-editor = pkgs.callPackage ./nix-editor.nix {
-            rev = if self ? rev then "0.0.0-${builtins.substring 0 7 self.rev}" else "0.0.0-dirty";
-          };
-        in
-        {
-          defaultPackage = nix-editor;
-          packages = {
-            inherit nix-editor;
-          };
-        }
-      );
+  outputs = { self, nixpkgs }: let
+    systems = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    eachSystem = nixpkgs.lib.genAttrs systems;
+    rev =
+      if self ? rev
+      then "0.0.0-${builtins.substring 0 7 self.rev}"
+      else "0.0.0-dirty";
+  in {
+    packages = eachSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in rec {
+      default = nix-editor;
+      nix-editor = pkgs.callPackage ./nix-editor.nix {
+        inherit rev;
+      };
+    });
+  };
 }


### PR DESCRIPTION
Why
===
* flake-utils is unneeded and more complex than necessary

What changed
===
* remove flake-utils input
* replace with an eachSystem function and system list

Test plan
===
* `nix build -L` works