### PR TITLE
doc: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
-***NOTE***: this package is deprecated. Use [UPM](https://github.com/replit/upm) with the `replit-nix` language to add deps to your Replit project instead!
-
-There's no plans to support other features in UPM.
-
----
-
-This is the replit.nix editor that is used by Goval to modify programatically interact with the file.
+This program edits Replit's replit.nix editor that is used by Goval to modify programatically interact with the file.
 
 It parses the file into an AST and traverses the AST to get the relevant information to modify the file.
 
 run `cargo run -- --help` to see what cli arguments are available.
+
+```
+nix-editor
+
+USAGE:
+    nix-editor [OPTIONS]
+
+OPTIONS:
+    -a, --add <ADD>              
+    -d, --dep-type <DEP_TYPE>    [default: regular] [possible values: regular, python]
+    -h, --human                  
+        --help                   Print help information
+    -p, --path <PATH>            
+    -r, --remove <REMOVE>        
+        --return-output          
+    -v, --verbose                
+    -V, --version                Print version information
+```
 
 You can directly add/remove packages through the cli args like so `cargo run -- --add pkgs.cowsay` or `cargo run -- --remove pkgs.cowsay` or `cargo run -- --get`.
 
@@ -16,5 +28,3 @@ You can also run it without passing in any flags. If you do that, it reads json 
 ```
 {"op":"add", "dep": "pkgs.cowsay" }
 ```
-
-


### PR DESCRIPTION
Why
===
* It said it was deprecated, but we're back to developing it.

What changed
===
* Removed deprecation notice
* Added cli output to make it easier to see the options

Test plan
===
* Look at readme in github