### PR TITLE
add: make replit.nix if missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,12 +189,12 @@ fn perform_op(
     // read replit.nix file
     let mut contents = match fs::read_to_string(replit_nix_filepath) {
         Ok(contents) => contents,
-        Err(_) => {
-            return (
-                "error".to_string(),
-                Some(format!("Could not read file {}", replit_nix_filepath)),
-            );
-        }
+        Err(_) => r#"
+{pkgs}:
+{
+  deps = [];
+}
+"#.to_string(),
     };
 
     let ast = rnix::parse(&contents);


### PR DESCRIPTION
Why
===
* Some templates don't have a replit.nix file.
* We should add it if we want to add a dep and it is missing.

What changed
===
* Set the contents to the default, empty replit.nix, if the file cannot be read

Test plan
===
```
mkdir testreplhome
cat testreplhome/replit.nix
REPL_HOME=testreplhome cargo run -- --add "pkgs.ncdu"
cat testreplhome/replit.nix
rm -r testreplhome
```