### PR TITLE
adder: modify syntax tree instead of strings

### DIFF
--- a/src/adder.rs
+++ b/src/adder.rs
@@ -24,16 +24,17 @@ pub fn add_dep(
         base_indent = w.text().replace("\n", "").len();
     }
     let entry_indent = base_indent + 2;
-    let base_whitespace = " ".repeat(base_indent);
-    let newline_whitespace = &format!("\n{base_whitespace}");
 
     let has_newline = deps_list
         .to_string()
         .contains('\n');
 
     let newline =  match has_newline {
-        true => "",
-        false => newline_whitespace,
+        true => String::new(),
+        false =>
+            std::iter::once("\n")
+            .chain(std::iter::repeat(" ")
+                   .take(base_indent)).collect(),
     };
 
     deps_list.splice_children(

--- a/src/adder.rs
+++ b/src/adder.rs
@@ -132,7 +132,7 @@ mod add_tests {
         "#)
     }
 
-    fn python_replit_nix() -> &'static str {
+    const PYTHON_REPLIT_NIX : &str =
         r#"{ pkgs }: {
   deps = [
     pkgs.python38Full
@@ -147,16 +147,15 @@ mod add_tests {
     PYTHONBIN = "${pkgs.python38Full}/bin/python3.8";
     LANG = "en_US.UTF-8";
   };
-}
-        "#
-    }
+}"#;
+
 
     #[test]
     fn test_regular_add_dep() {
         test_add(
             DepType::Regular,
             "pkgs.test",
-            python_replit_nix(),
+            PYTHON_REPLIT_NIX,
             r#"{ pkgs }: {
   deps = [
     pkgs.test
@@ -172,8 +171,7 @@ mod add_tests {
     PYTHONBIN = "${pkgs.python38Full}/bin/python3.8";
     LANG = "en_US.UTF-8";
   };
-}
-        "#);
+}"#);
     }
 
     #[test]
@@ -181,7 +179,7 @@ mod add_tests {
         test_add(
             DepType::Python,
             "pkgs.test",
-            python_replit_nix(),
+            PYTHON_REPLIT_NIX,
             r#"{ pkgs }: {
   deps = [
     pkgs.python38Full
@@ -197,8 +195,7 @@ mod add_tests {
     PYTHONBIN = "${pkgs.python38Full}/bin/python3.8";
     LANG = "en_US.UTF-8";
   };
-}
-        "#);
+}"#);
     }
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,7 +199,7 @@ fn perform_op(
 
     let ast = rnix::Root::parse(&contents);
 
-    let deps_list = match verify_get(ast.syntax(), dep_type) {
+    let deps_list = match verify_get(&ast.syntax(), dep_type) {
         Ok(deps_list) => deps_list,
         Err(_) => {
             return (
@@ -210,10 +210,10 @@ fn perform_op(
     };
 
     let op_res = match op {
-        OpKind::Add => add_dep(&mut contents, deps_list, dep),
-        OpKind::Remove => remove_dep(&mut contents, deps_list, dep),
+        OpKind::Add => add_dep(deps_list, dep).map(|node| node.to_string()),
+        OpKind::Remove => remove_dep(&mut contents, deps_list.node, dep),
         OpKind::Get => {
-            let deps = match get_deps(deps_list) {
+            let deps = match get_deps(deps_list.node) {
                 Ok(deps) => deps,
                 Err(_) => {
                     return ("error".to_string(), Some("Could not get deps".to_string()));

--- a/src/remover.rs
+++ b/src/remover.rs
@@ -80,14 +80,14 @@ mod remove_tests {
     fn test_regular_remove_dep() {
         let mut contents = python_replit_nix();
         let tree = rnix::Root::parse(&contents).syntax();
-        let deps_list_res = verify_get(tree, DepType::Regular);
+        let deps_list_res = verify_get(&tree, DepType::Regular);
         assert!(deps_list_res.is_ok());
 
         let deps_list = deps_list_res.unwrap();
 
         let dep_to_remove = "pkgs.python38Full";
 
-        let new_contents = remove_dep(&mut contents, deps_list, Some(dep_to_remove.to_string()));
+        let new_contents = remove_dep(&mut contents, deps_list.node, Some(dep_to_remove.to_string()));
         assert!(new_contents.is_ok());
 
         let new_contents = new_contents.unwrap();
@@ -116,14 +116,14 @@ mod remove_tests {
     fn test_python_remove_dep() {
         let mut contents = python_replit_nix();
         let tree = rnix::Root::parse(&contents).syntax();
-        let deps_list_res = verify_get(tree, DepType::Python);
+        let deps_list_res = verify_get(&tree, DepType::Python);
         assert!(deps_list_res.is_ok());
 
         let deps_list = deps_list_res.unwrap();
 
         let dep_to_remove = "pkgs.glib";
 
-        let new_contents = remove_dep(&mut contents, deps_list, Some(dep_to_remove.to_string()));
+        let new_contents = remove_dep(&mut contents, deps_list.node, Some(dep_to_remove.to_string()));
         assert!(new_contents.is_ok());
 
         let new_contents = new_contents.unwrap();

--- a/src/verify_getter.rs
+++ b/src/verify_getter.rs
@@ -16,11 +16,16 @@ macro_rules! verify_eq {
     };
 }
 
+pub struct SyntaxNodeAndWhitespace {
+    pub whitespace: Option<SyntaxToken>,
+    pub node: SyntaxNode
+}
+
 // Will try to parse through the AST and return a list of deps
 // If at any point, the tree is not *exactly* how we expect it to look,
 // it will return an error. Since nix is so complex, we have to require some
 // assumptions about the AST, or else it'll be impossible to do anything.
-pub fn verify_get(root: SyntaxNode, dep_type: DepType) -> Result<SyntaxNode> {
+pub fn verify_get(root: &SyntaxNode, dep_type: DepType) -> Result<SyntaxNodeAndWhitespace> {
     verify_eq!(root.kind(), SyntaxKind::NODE_ROOT);
 
     let lambda = get_nth_child(&root, 0).context("expected to have a child")?;
@@ -37,25 +42,27 @@ pub fn verify_get(root: SyntaxNode, dep_type: DepType) -> Result<SyntaxNode> {
     verify_eq!(attr_set.kind(), SyntaxKind::NODE_ATTR_SET);
 
     let deps_list = match dep_type {
-        DepType::Regular => verify_get_regular(attr_set)?,
-        DepType::Python => verify_get_python(attr_set)?,
+        DepType::Regular => verify_get_regular(&attr_set)?,
+        DepType::Python => verify_get_python(&attr_set)?,
     };
 
     Ok(deps_list)
 }
 
-fn verify_get_regular(attr_set: SyntaxNode) -> Result<SyntaxNode> {
+fn verify_get_regular(attr_set: &SyntaxNode) -> Result<SyntaxNodeAndWhitespace> {
     let deps = find_key_value_with_key(&attr_set, "deps").context("expected to have a deps key")?;
+    let whitespace = deps.whitespace;
+    let deps = deps.node;
     verify_eq!(deps.kind(), SyntaxKind::NODE_ATTRPATH_VALUE);
 
     let deps_list = get_nth_child(&deps, 1).context("expected to have two children")?;
     verify_eq!(deps_list.kind(), SyntaxKind::NODE_LIST);
 
-    Ok(deps_list)
+    Ok(SyntaxNodeAndWhitespace { whitespace, node: deps_list})
 }
 
-fn verify_get_python(attr_set: SyntaxNode) -> Result<SyntaxNode> {
-    let env = find_key_value_with_key(&attr_set, "env").context("expected to have an env key")?;
+fn verify_get_python(attr_set: &SyntaxNode) -> Result<SyntaxNodeAndWhitespace> {
+    let env = find_key_value_with_key(&attr_set, "env").context("expected to have an env key")?.node;
     verify_eq!(env.kind(), SyntaxKind::NODE_ATTRPATH_VALUE);
 
     let env_attr_set = get_nth_child(&env, 1).context("expected to have two children")?;
@@ -63,6 +70,8 @@ fn verify_get_python(attr_set: SyntaxNode) -> Result<SyntaxNode> {
 
     let py_lib_path = find_key_value_with_key(&env_attr_set, "PYTHON_LD_LIBRARY_PATH")
         .context("expected to have a PYTHON_LD_LIBRARY_PATH key")?;
+    let whitespace = py_lib_path.whitespace;
+    let py_lib_path = py_lib_path.node;
     verify_eq!(py_lib_path.kind(), SyntaxKind::NODE_ATTRPATH_VALUE);
 
     let py_lib_apply = get_nth_child(&py_lib_path, 1).context("expected to have two children")?;
@@ -76,7 +85,7 @@ fn verify_get_python(attr_set: SyntaxNode) -> Result<SyntaxNode> {
         get_nth_child(&py_lib_apply, 1).context("expected to have two children")?;
     verify_eq!(py_lib_node_list.kind(), SyntaxKind::NODE_LIST);
 
-    Ok(py_lib_node_list)
+    Ok(SyntaxNodeAndWhitespace { whitespace, node: py_lib_node_list})
 }
 
 fn get_nth_child(node: &SyntaxNode, index: usize) -> Option<SyntaxNode> {
@@ -89,23 +98,51 @@ fn find_child_with_value(node: &SyntaxNode, name: &str) -> Option<SyntaxNode> {
         .find(|child| child.text() == name)
 }
 
-fn find_key_value_with_key(node: &SyntaxNode, key: &str) -> Option<SyntaxNode> {
+fn find_key_value_with_key(node: &SyntaxNode, key: &str) -> Option<SyntaxNodeAndWhitespace> {
     if node.kind() != SyntaxKind::NODE_ATTR_SET {
         return None;
     }
 
-    node.children().into_iter().find(|child| {
-        if child.kind() != SyntaxKind::NODE_ATTRPATH_VALUE {
+    let mut last_whitespace = None;
+
+    let node = node.children_with_tokens().into_iter().find(|child| {
+        if let Some(token) = child.as_token() {
+            if token.kind() != SyntaxKind::TOKEN_WHITESPACE {
+                return false;
+            }
+            let w = token.text();
+            if !w.contains("\n") {
+                return false;
+            }
+            last_whitespace = Some(token.clone());
+            return false;
+        }
+        if child.as_node().is_none() {
             return false;
         }
 
-        let key_node = match get_nth_child(child, 0) {
+        let node = child.as_node().unwrap();
+
+        if node.kind() != SyntaxKind::NODE_ATTRPATH_VALUE {
+            return false;
+        }
+
+        let key_node = match get_nth_child(node, 0) {
             Some(child) => child,
             None => return false,
         };
 
         key_node.text() == key
-    })
+    });
+
+    match node {
+        Some(node_or_token) =>
+             Some(SyntaxNodeAndWhitespace {
+                 whitespace: last_whitespace,
+                 node: node_or_token.as_node().unwrap().clone(),
+             }),
+        _ => None,
+    }
 }
 
 // unit tests
@@ -140,11 +177,15 @@ mod verify_get_tests {
     #[test]
     fn verify_get_python() {
         let ast = python_replit_nix_ast();
-        let deps_list_res = verify_get(ast, DepType::Python);
+        let deps_list_res = verify_get(&ast, DepType::Python);
 
         assert!(deps_list_res.is_ok());
 
         let deps_list = deps_list_res.unwrap();
+        let whitespace = deps_list.whitespace.unwrap();
+        assert_eq!(whitespace.to_string().len(), 5);
+
+        let deps_list = deps_list.node;
         let deps_list_children: Vec<SyntaxNode> = deps_list.children().collect();
 
         assert_eq!(deps_list_children.len(), 4);
@@ -171,11 +212,11 @@ mod verify_get_tests {
     #[test]
     fn verify_get_regular() {
         let ast = python_replit_nix_ast();
-        let deps_list_res = verify_get(ast, DepType::Regular);
+        let deps_list_res = verify_get(&ast, DepType::Regular);
 
         assert!(deps_list_res.is_ok());
 
-        let deps_list = deps_list_res.unwrap();
+        let deps_list = deps_list_res.unwrap().node;
         let deps_list_children: Vec<SyntaxNode> = deps_list.children().collect();
 
         assert_eq!(deps_list_children.len(), 1);


### PR DESCRIPTION
Why
===
* nix-editor was doing string manipulation inside of adder on the entire contents of the document.
* With this commit, now splice the syntax tree, and only allow editing the deps_list part passed in, instead of the whole tree.
* Also, use the earlier whitespace in the document as a clue for how deeply to indent the entries, which fixes and normalizes a variety of edge cases.
* The adder test cases had some redundant code paths.

What changed
===
* In verify_get, also record the last whitespace we've seen with a newline in it. Then use this to determine what level to indent addtional entries.
* Modify verify_get to take the tree as a borrow, because we need to have the deps_list be referencing the same memory as the tree, so that add can modify the tree datastructure in place later.
* Make a new SyntaxNodeAndWhitespace struct to store the node next to the whitespace. The whitespace is optional because there might not be any.
* Change add_dep to  no longer pass in  the contents of the  file as a string. Also, change  it to return a modified SyntaxNode  instead of a String.
* Use splice_children to change the SyntaxNode
* Remove clowny indenting code and use the Whitespace passed in, if available.
* Add more tests to verify indenting
* Simplify the adder tests for Python entry adds to use the same test helper as the regular adds

Test plan
===
* nix develop
* cargo test