### PR TITLE
contrib: add a nix deveshell and fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ You can also run it without passing in any flags. If you do that, it reads json 
 ```
 {"op":"add", "dep": "pkgs.cowsay" }
 ```
+
+# Contributing
+
+* Please run `nix fmt` to format the code in this repository before making a pull request.
+* `nix develop` will put you in a devshell with all the necessary development tools.

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,10 @@
 # flake-compat makes Nix flakes compatible with the old Nix cli commands, like nix-build and nix-shell.
 (import (
-  fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
-) {
-  src =  ./.;
-}).defaultNix
-
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+      sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+    }
+  ) {
+    src = ./.;
+  })
+.defaultNix

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,10 @@
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
-  outputs = { self, nixpkgs }: let
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
     systems = [
       "aarch64-darwin"
       "aarch64-linux"
@@ -23,6 +26,12 @@
       nix-editor = pkgs.callPackage ./nix-editor.nix {
         inherit rev;
       };
+      devShell = pkgs.callPackage ./nix/devshell {};
+      fmt = pkgs.callPackage ./nix/fmt {};
     });
+    devShells = eachSystem (system: {
+      default = self.packages.${system}.devShell;
+    });
+    formatter = eachSystem (system: self.packages.${system}.fmt);
   };
 }

--- a/nix-editor.nix
+++ b/nix-editor.nix
@@ -1,13 +1,14 @@
-{ rustPlatform, rev }:
-
+{
+  rustPlatform,
+  rev,
+}:
 rustPlatform.buildRustPackage {
-    pname = "nix-editor";
-    version = rev;
+  pname = "nix-editor";
+  version = rev;
 
-    cargoLock = {
-      lockFile = ./Cargo.lock;
-    };
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
 
-    src = ./.;
+  src = ./.;
 }
-

--- a/nix/devshell/default.nix
+++ b/nix/devshell/default.nix
@@ -1,0 +1,12 @@
+{
+  rustc,
+  rustfmt,
+  mkShell,
+}:
+mkShell {
+  name = "nix-editor";
+  packages = [
+    rustc
+    rustfmt
+  ];
+}

--- a/nix/fmt/default.nix
+++ b/nix/fmt/default.nix
@@ -1,0 +1,11 @@
+{
+  writeScriptBin,
+  alejandra,
+  rustfmt,
+}:
+writeScriptBin "fmt" ''
+  echo "Formatting Nix code..."
+  ${alejandra}/bin/alejandra -q .
+  echo "Formatting Rust code..."
+  ${rustfmt}/bin/cargo-fmt
+''

--- a/src/adder.rs
+++ b/src/adder.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rnix::{SyntaxNode};
+use rnix::SyntaxNode;
 
 use crate::verify_getter::SyntaxNodeAndWhitespace;
 
@@ -7,7 +7,6 @@ pub fn add_dep(
     deps_list: SyntaxNodeAndWhitespace,
     new_dep_opt: Option<String>,
 ) -> Result<SyntaxNode> {
-
     let new_dep = new_dep_opt.context("error: no dependency")?;
     let whitespace = deps_list.whitespace;
     let deps_list = deps_list.node;
@@ -25,26 +24,26 @@ pub fn add_dep(
     }
     let entry_indent = base_indent + 2;
 
-    let has_newline = deps_list
-        .to_string()
-        .contains('\n');
+    let has_newline = deps_list.to_string().contains('\n');
 
-    let newline =  match has_newline {
+    let newline = match has_newline {
         true => String::new(),
-        false =>
-            std::iter::once("\n")
-            .chain(std::iter::repeat(" ")
-                   .take(base_indent)).collect(),
+        false => std::iter::once("\n")
+            .chain(std::iter::repeat(" ").take(base_indent))
+            .collect(),
     };
 
     deps_list.splice_children(
         1..1,
-        vec![
-            rnix::NodeOrToken::Node(
-                rnix::Root::parse(
-                    &format!("\n{}{}{newline}", &" ".repeat(entry_indent), new_dep))
-                    .syntax().clone_for_update()),
-        ]
+        vec![rnix::NodeOrToken::Node(
+            rnix::Root::parse(&format!(
+                "\n{}{}{newline}",
+                &" ".repeat(entry_indent),
+                new_dep
+            ))
+            .syntax()
+            .clone_for_update(),
+        )],
     );
 
     Ok(deps_list)
@@ -57,7 +56,9 @@ mod add_tests {
     use crate::DepType;
 
     fn test_add(dep_type: DepType, new_dep: &str, initial_contents: &str, expected_contents: &str) {
-        let tree = rnix::Root::parse(&initial_contents).syntax().clone_for_update();
+        let tree = rnix::Root::parse(&initial_contents)
+            .syntax()
+            .clone_for_update();
 
         let deps_list_res = verify_get(&tree, dep_type);
         assert!(deps_list_res.is_ok());
@@ -75,16 +76,17 @@ mod add_tests {
         test_add(
             DepType::Regular,
             "pkgs.test",
-        r#"{ pkgs }: {
+            r#"{ pkgs }: {
     deps = [];
 }
         "#,
-        r#"{ pkgs }: {
+            r#"{ pkgs }: {
     deps = [
       pkgs.test
     ];
 }
-        "#)
+        "#,
+        )
     }
 
     #[test]
@@ -93,9 +95,10 @@ mod add_tests {
             DepType::Regular,
             "pkgs.test",
             r#"{ pkgs }: { deps = []; }"#,
-        r#"{ pkgs }: { deps = [
+            r#"{ pkgs }: { deps = [
   pkgs.test
-]; }"#)
+]; }"#,
+        )
     }
 
     #[test]
@@ -111,7 +114,8 @@ mod add_tests {
   deps = [
     pkgs.test
   ];
-}"#)
+}"#,
+        )
     }
 
     #[test]
@@ -119,22 +123,22 @@ mod add_tests {
         test_add(
             DepType::Regular,
             "pkgs.test",
-        r#"{ pkgs }: {
+            r#"{ pkgs }: {
   deps = [
     pkgs.test
   ];
 }
         "#,
-        r#"{ pkgs }: {
+            r#"{ pkgs }: {
   deps = [
     pkgs.test
   ];
 }
-        "#)
+        "#,
+        )
     }
 
-    const PYTHON_REPLIT_NIX : &str =
-        r#"{ pkgs }: {
+    const PYTHON_REPLIT_NIX: &str = r#"{ pkgs }: {
   deps = [
     pkgs.python38Full
   ];
@@ -149,7 +153,6 @@ mod add_tests {
     LANG = "en_US.UTF-8";
   };
 }"#;
-
 
     #[test]
     fn test_regular_add_dep() {
@@ -172,7 +175,8 @@ mod add_tests {
     PYTHONBIN = "${pkgs.python38Full}/bin/python3.8";
     LANG = "en_US.UTF-8";
   };
-}"#);
+}"#,
+        );
     }
 
     #[test]
@@ -196,7 +200,7 @@ mod add_tests {
     PYTHONBIN = "${pkgs.python38Full}/bin/python3.8";
     LANG = "en_US.UTF-8";
   };
-}"#);
+}"#,
+        );
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use rnix::SyntaxNode;
 
 use std::fs;
-use std::{io, io::prelude::*, path::Path, env};
+use std::{env, io, io::prelude::*, path::Path};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{from_str, to_string};
@@ -72,7 +72,9 @@ pub enum DepType {
 }
 
 impl Default for DepType {
-    fn default() -> Self { DepType::Regular }
+    fn default() -> Self {
+        DepType::Regular
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -94,18 +96,18 @@ fn main() {
     real_main(args)
 }
 
-fn real_main(args:Args) {
+fn real_main(args: Args) {
     let replit_nix_file = "./replit.nix";
-    let default_replit_nix_filepath : String = match env::var("REPL_HOME") {
-        Ok(repl_home) => Path::new(repl_home.as_str()).
-            join(replit_nix_file).to_str().unwrap().to_string(),
+    let default_replit_nix_filepath: String = match env::var("REPL_HOME") {
+        Ok(repl_home) => Path::new(repl_home.as_str())
+            .join(replit_nix_file)
+            .to_str()
+            .unwrap()
+            .to_string(),
         Err(_) => replit_nix_file.to_string(),
     };
 
-
-    let replit_nix_filepath = args
-        .path
-        .unwrap_or_else(|| default_replit_nix_filepath);
+    let replit_nix_filepath = args.path.unwrap_or_else(|| default_replit_nix_filepath);
 
     let human_readable = args.human;
     let verbose = args.verbose;
@@ -182,7 +184,7 @@ fn real_main(args:Args) {
     }
 }
 
-const EMPTY_TEMPLATE : &str = r#"{pkgs}: {
+const EMPTY_TEMPLATE: &str = r#"{pkgs}: {
   deps = [];
 }
 "#;
@@ -250,7 +252,10 @@ fn perform_op(
         Ok(_) => ("success".to_string(), None),
         Err(err) => (
             "error".to_string(),
-            Some(format!("Could not write to file {}: {}", replit_nix_filepath, err)),
+            Some(format!(
+                "Could not write to file {}: {}",
+                replit_nix_filepath, err
+            )),
         ),
     }
 }
@@ -294,7 +299,6 @@ fn get_deps(deps_list: SyntaxNode) -> Result<Vec<String>> {
         .collect())
 }
 
-
 #[cfg(test)]
 mod integration_tests {
     use super::*;
@@ -313,12 +317,15 @@ mod integration_tests {
 
         let contents = fs::read_to_string(repl_nix_file.clone()).unwrap();
 
-        assert_eq!(r#"{pkgs}: {
+        assert_eq!(
+            r#"{pkgs}: {
   deps = [
     pkgs.ncdu
   ];
 }
-"#, contents);
+"#,
+            contents
+        );
 
         drop(repl_nix_file);
         dir.close().unwrap();
@@ -341,7 +348,8 @@ mod integration_tests {
 
         let contents = fs::read_to_string(repl_nix_file.clone()).unwrap();
 
-        assert_eq!(r#"{pkgs}: {
+        assert_eq!(
+            r#"{pkgs}: {
   deps = [];
   env = {
     PYTHON_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
@@ -350,7 +358,8 @@ mod integration_tests {
   };
 }
 "#,
-                   contents);
+            contents
+        );
         drop(repl_nix_file);
         dir.close().unwrap();
     }

--- a/src/remover.rs
+++ b/src/remover.rs
@@ -87,7 +87,11 @@ mod remove_tests {
 
         let dep_to_remove = "pkgs.python38Full";
 
-        let new_contents = remove_dep(&mut contents, deps_list.node, Some(dep_to_remove.to_string()));
+        let new_contents = remove_dep(
+            &mut contents,
+            deps_list.node,
+            Some(dep_to_remove.to_string()),
+        );
         assert!(new_contents.is_ok());
 
         let new_contents = new_contents.unwrap();
@@ -123,7 +127,11 @@ mod remove_tests {
 
         let dep_to_remove = "pkgs.glib";
 
-        let new_contents = remove_dep(&mut contents, deps_list.node, Some(dep_to_remove.to_string()));
+        let new_contents = remove_dep(
+            &mut contents,
+            deps_list.node,
+            Some(dep_to_remove.to_string()),
+        );
         assert!(new_contents.is_ok());
 
         let new_contents = new_contents.unwrap();

--- a/src/verify_getter.rs
+++ b/src/verify_getter.rs
@@ -19,7 +19,7 @@ macro_rules! verify_eq {
 #[derive(Debug)]
 pub struct SyntaxNodeAndWhitespace {
     pub whitespace: Option<SyntaxToken>,
-    pub node: SyntaxNode
+    pub node: SyntaxNode,
 }
 
 // Will try to parse through the AST and return a list of deps
@@ -51,10 +51,7 @@ pub fn verify_get(root: &SyntaxNode, dep_type: DepType) -> Result<SyntaxNodeAndW
 }
 
 fn verify_get_regular(attr_set: &SyntaxNode) -> Result<SyntaxNodeAndWhitespace> {
-    let deps = find_or_insert_key_value_with_key(
-        &attr_set,
-        "deps",
-        template_deps())
+    let deps = find_or_insert_key_value_with_key(&attr_set, "deps", template_deps())
         .context("expected to have a deps key")?;
     let whitespace = deps.whitespace;
     let deps = deps.node;
@@ -63,20 +60,30 @@ fn verify_get_regular(attr_set: &SyntaxNode) -> Result<SyntaxNodeAndWhitespace> 
     let deps_list = get_nth_child(&deps, 1).context("expected to have two children")?;
     verify_eq!(deps_list.kind(), SyntaxKind::NODE_LIST);
 
-    Ok(SyntaxNodeAndWhitespace { whitespace, node: deps_list})
+    Ok(SyntaxNodeAndWhitespace {
+        whitespace,
+        node: deps_list,
+    })
 }
 
-fn find_or_insert_key_value_with_key(node: &SyntaxNode, key: &str, if_missing_template: SyntaxNode) -> Option<SyntaxNodeAndWhitespace> {
+fn find_or_insert_key_value_with_key(
+    node: &SyntaxNode,
+    key: &str,
+    if_missing_template: SyntaxNode,
+) -> Option<SyntaxNodeAndWhitespace> {
     let found = find_key_value_with_key(&node, key);
     if found.is_some() {
         return found;
     }
     let count = node.children().count() + 2;
 
-    node.splice_children(count..count, vec![
-        rnix::NodeOrToken::Node(rnix::Root::parse("\n  ").syntax().clone_for_update()),
-        rnix::NodeOrToken::Node(if_missing_template),
-    ]);
+    node.splice_children(
+        count..count,
+        vec![
+            rnix::NodeOrToken::Node(rnix::Root::parse("\n  ").syntax().clone_for_update()),
+            rnix::NodeOrToken::Node(if_missing_template),
+        ],
+    );
 
     let result = find_key_value_with_key(&node, key);
     result
@@ -91,7 +98,12 @@ fn template_deps() -> SyntaxNode {
     if errors.len() > 0 {
         panic!("add_syntax_node had error: {:#?}", errors)
     }
-    ast.syntax().first_child().unwrap().first_child().unwrap().clone_for_update()
+    ast.syntax()
+        .first_child()
+        .unwrap()
+        .first_child()
+        .unwrap()
+        .clone_for_update()
 }
 
 fn template_env() -> SyntaxNode {
@@ -105,7 +117,12 @@ fn template_env() -> SyntaxNode {
     if errors.len() > 0 {
         panic!("add_syntax_node had error: {:#?}", errors)
     }
-    ast.syntax().first_child().unwrap().first_child().unwrap().clone_for_update()
+    ast.syntax()
+        .first_child()
+        .unwrap()
+        .first_child()
+        .unwrap()
+        .clone_for_update()
 }
 
 fn template_python() -> SyntaxNode {
@@ -117,15 +134,18 @@ fn template_python() -> SyntaxNode {
     if errors.len() > 0 {
         panic!("add_syntax_node had error: {:#?}", errors)
     }
-    ast.syntax().first_child().unwrap().first_child().unwrap().clone_for_update()
+    ast.syntax()
+        .first_child()
+        .unwrap()
+        .first_child()
+        .unwrap()
+        .clone_for_update()
 }
 
 fn verify_get_python(attr_set: &SyntaxNode) -> Result<SyntaxNodeAndWhitespace> {
-    let env = find_or_insert_key_value_with_key(
-        &attr_set,
-        "env",
-        template_env())
-        .context("expected to have env key")?.node;
+    let env = find_or_insert_key_value_with_key(&attr_set, "env", template_env())
+        .context("expected to have env key")?
+        .node;
     verify_eq!(env.kind(), SyntaxKind::NODE_ATTRPATH_VALUE);
 
     let env_attr_set = get_nth_child(&env, 1).context("expected to have two children")?;
@@ -134,8 +154,9 @@ fn verify_get_python(attr_set: &SyntaxNode) -> Result<SyntaxNodeAndWhitespace> {
     let py_lib_path = find_or_insert_key_value_with_key(
         &env_attr_set,
         "PYTHON_LD_LIBRARY_PATH",
-        template_python())
-        .context("expected to have PYTHON_LD_LIBRARY_PATH key")?;
+        template_python(),
+    )
+    .context("expected to have PYTHON_LD_LIBRARY_PATH key")?;
     let whitespace = py_lib_path.whitespace;
     let py_lib_path = py_lib_path.node;
     verify_eq!(py_lib_path.kind(), SyntaxKind::NODE_ATTRPATH_VALUE);
@@ -151,7 +172,10 @@ fn verify_get_python(attr_set: &SyntaxNode) -> Result<SyntaxNodeAndWhitespace> {
         get_nth_child(&py_lib_apply, 1).context("expected to have two children")?;
     verify_eq!(py_lib_node_list.kind(), SyntaxKind::NODE_LIST);
 
-    Ok(SyntaxNodeAndWhitespace { whitespace, node: py_lib_node_list})
+    Ok(SyntaxNodeAndWhitespace {
+        whitespace,
+        node: py_lib_node_list,
+    })
 }
 
 fn get_nth_child(node: &SyntaxNode, index: usize) -> Option<SyntaxNode> {
@@ -202,11 +226,10 @@ fn find_key_value_with_key(node: &SyntaxNode, key: &str) -> Option<SyntaxNodeAnd
     });
 
     match node {
-        Some(node_or_token) =>
-             Some(SyntaxNodeAndWhitespace {
-                 whitespace: last_whitespace,
-                 node: node_or_token.as_node().unwrap().clone(),
-             }),
+        Some(node_or_token) => Some(SyntaxNodeAndWhitespace {
+            whitespace: last_whitespace,
+            node: node_or_token.as_node().unwrap().clone(),
+        }),
         _ => None,
     }
 }
@@ -252,9 +275,12 @@ mod verify_get_tests {
 
     #[test]
     fn verify_get_when_missing_env() {
-        let deps_list = gets_ok(r#"{ pkgs }: {
+        let deps_list = gets_ok(
+            r#"{ pkgs }: {
   deps = [];
-}"#, DepType::Python);
+}"#,
+            DepType::Python,
+        );
         let deps_list = deps_list.node;
         let deps_list_children: Vec<SyntaxNode> = deps_list.children().collect();
         assert_eq!(deps_list_children.len(), 0);
@@ -262,10 +288,13 @@ mod verify_get_tests {
 
     #[test]
     fn verify_get_when_missing_python() {
-        let deps_list = gets_ok(r#"{ pkgs }: {
+        let deps_list = gets_ok(
+            r#"{ pkgs }: {
   deps = [];
   env = {};
-}"#, DepType::Python);
+}"#,
+            DepType::Python,
+        );
         let deps_list = deps_list.node;
         let deps_list_children: Vec<SyntaxNode> = deps_list.children().collect();
         assert_eq!(deps_list_children.len(), 0);


### PR DESCRIPTION
Why
===
* Our code was deviating from the rustfmt standard
* We didn't have a proper devshell, it was just using the devshell of the default package

What changed
===
* Added `nix develop` devshell
* Added `nix fmt`
* Formatted nix and rust code

Test plan
===
* cargo build still works
* nix build still works