### PR TITLE
only create replit.nix if the file is not found, not on other errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,14 @@ fn perform_op(
     // read replit.nix file
     let mut contents = match fs::read_to_string(replit_nix_filepath) {
         Ok(contents) => contents,
-        Err(_) => EMPTY_TEMPLATE.to_string(),
+        // if replit.nix doesn't exist start with an empty one
+        Err(err) if err.kind() == io::ErrorKind::NotFound => EMPTY_TEMPLATE.to_string(),
+        Err(_) => {
+            return (
+                "error".to_string(),
+                Some(format!("error: reading file - {:?}", &replit_nix_filepath)),
+            )
+        }
     };
 
     let root = rnix::Root::parse(&contents).syntax().clone_for_update();


### PR DESCRIPTION
Why
===
* Other filesystem errors could result in overwriting an existing replit.nix file, so lets only do this if the file is truly not found

What changed
===
* Only return the empty template if we get a NotFound error. Otherwise, bail early like before.

Test plan
===
* Confirm that we still make a replit.nix: `cargo run -- --path=test-replit.nix --add pkgs.ncdu`