### PR TITLE
fix adding when deps has with pkgs;

### DIFF
--- a/src/adder.rs
+++ b/src/adder.rs
@@ -138,6 +138,27 @@ mod add_tests {
         )
     }
 
+    #[test]
+    fn test_with_pkgs_add() {
+        test_add(
+            DepType::Regular,
+            "pkgs.ncdu",
+            r#"{ pkgs }: {
+  deps = with pkgs; [
+    test
+  ];
+}
+        "#,
+            r#"{ pkgs }: {
+  deps = with pkgs; [
+    pkgs.ncdu
+    test
+  ];
+}
+        "#,
+        )
+    }
+
     const PYTHON_REPLIT_NIX: &str = r#"{ pkgs }: {
   deps = [
     pkgs.python38Full

--- a/src/remover.rs
+++ b/src/remover.rs
@@ -77,6 +77,42 @@ mod remove_tests {
     }
 
     #[test]
+    fn test_regular_remove_with_pkgs_dep() {
+        let contents = r#"{ pkgs }: {
+  deps = with pkgs; [
+    pkgs.ncdu
+    test
+  ];
+}
+        "#;
+
+        let tree = rnix::Root::parse(&contents).syntax();
+        let deps_list_res = verify_get(&tree, DepType::Regular);
+        assert!(deps_list_res.is_ok());
+
+        let deps_list = deps_list_res.unwrap();
+
+        let dep_to_remove = "pkgs.ncdu";
+
+        let new_contents = remove_dep(
+            &mut contents.to_string(),
+            deps_list.node,
+            Some(dep_to_remove.to_string()),
+        );
+        assert!(new_contents.is_ok());
+
+        let new_contents = new_contents.unwrap();
+
+        let expected_contents = r#"{ pkgs }: {
+  deps = with pkgs; [
+    test
+  ];
+}
+        "#;
+        assert_eq!(new_contents, expected_contents);
+    }
+
+    #[test]
     fn test_regular_remove_dep() {
         let mut contents = python_replit_nix();
         let tree = rnix::Root::parse(&contents).syntax();

--- a/src/verify_getter.rs
+++ b/src/verify_getter.rs
@@ -61,7 +61,15 @@ fn verify_get_regular(attr_set: &SyntaxNode) -> Result<SyntaxNodeAndWhitespace> 
     let deps = deps.node;
     verify_eq!(deps.kind(), SyntaxKind::NODE_ATTRPATH_VALUE);
 
-    let deps_list = get_nth_child(&deps, 1).context("expected to have two children")?;
+    let value = get_nth_child(&deps, 1).context("expected to have two children")?;
+
+    let deps_list = match value.kind() {
+        SyntaxKind::NODE_LIST => value,
+        SyntaxKind::NODE_WITH => {
+            get_nth_child(&value, 1).context("expected to have at least two children")?
+        }
+        _ => bail!("unexpected value for deps, expected either with pkgs; or a list"),
+    };
     verify_eq!(deps_list.kind(), SyntaxKind::NODE_LIST);
 
     Ok(SyntaxNodeAndWhitespace {


### PR DESCRIPTION
Why
===
* Sometimes people write

```
deps = with pkgs; [
     test
];
```
* if they do, we crash.
* let's not crash.

What changed
===
* Add tests for adding and removing with with_pkgs
* Made test case pass

Test plan
===
* cargo test passes