### PR TITLE
remove should edit file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,7 @@ fn perform_op(
 
     let op_res = match op {
         OpKind::Add => add_dep(deps_list, dep).map(|_| root.to_string()),
-        OpKind::Remove => remove_dep(&mut contents.clone(), deps_list.node, dep),
+        OpKind::Remove => remove_dep(&contents, deps_list.node, dep),
         OpKind::Get => {
             let deps = match get_deps(deps_list.node) {
                 Ok(deps) => deps,

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,13 +189,6 @@ const EMPTY_TEMPLATE: &str = r#"{pkgs}: {
 }
 "#;
 
-const TEMPLATE: &str = r#"{pkgs}: {
-  deps = [
-    pkgs.cowsay
-  ];
-}
-"#;
-
 fn perform_op(
     op: OpKind,
     dep: Option<String>,
@@ -321,6 +314,13 @@ fn get_deps(deps_list: SyntaxNode) -> Result<Vec<String>> {
 mod integration_tests {
     use super::*;
 
+    const TEMPLATE: &str = r#"{pkgs}: {
+  deps = [
+    pkgs.cowsay
+  ];
+}
+"#;
+
     #[test]
     fn test_integration_makes_template_if_missing() {
         let dir = tempfile::tempdir().unwrap();
@@ -424,8 +424,7 @@ mod integration_tests {
 
         let contents = fs::read_to_string(repl_nix_file.clone()).unwrap();
 
-        assert_eq!("{pkgs}: {\n  deps = [\n  ];\n}\n",
-                   contents);
+        assert_eq!("{pkgs}: {\n  deps = [\n  ];\n}\n", contents);
 
         drop(repl_nix_file);
         dir.close().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,13 @@ const EMPTY_TEMPLATE: &str = r#"{pkgs}: {
 }
 "#;
 
+const TEMPLATE: &str = r#"{pkgs}: {
+  deps = [
+    pkgs.cowsay
+  ];
+}
+"#;
+
 fn perform_op(
     op: OpKind,
     dep: Option<String>,
@@ -202,7 +209,7 @@ fn perform_op(
     }
 
     // read replit.nix file
-    let mut contents = match fs::read_to_string(replit_nix_filepath) {
+    let contents = match fs::read_to_string(replit_nix_filepath) {
         Ok(contents) => contents,
         // if replit.nix doesn't exist start with an empty one
         Err(err) if err.kind() == io::ErrorKind::NotFound => EMPTY_TEMPLATE.to_string(),
@@ -228,7 +235,7 @@ fn perform_op(
 
     let op_res = match op {
         OpKind::Add => add_dep(deps_list, dep).map(|_| root.to_string()),
-        OpKind::Remove => remove_dep(&mut contents, deps_list.node, dep),
+        OpKind::Remove => remove_dep(&mut contents.clone(), deps_list.node, dep),
         OpKind::Get => {
             let deps = match get_deps(deps_list.node) {
                 Ok(deps) => deps,
@@ -398,5 +405,29 @@ mod integration_tests {
         let modification_time2 = metadata.modified().unwrap();
 
         assert_eq!(modification_time, modification_time2);
+    }
+
+    #[test]
+    fn test_integration_remove_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let repl_nix_file = dir.path().join("replit.nix");
+
+        fs::write(repl_nix_file.as_os_str(), TEMPLATE.as_bytes()).unwrap();
+        let args = Args {
+            path: Some(repl_nix_file.clone().display().to_string()),
+            dep_type: DepType::Regular,
+            remove: Some("pkgs.cowsay".to_string()),
+            verbose: true,
+            ..Default::default()
+        };
+        real_main(args.clone());
+
+        let contents = fs::read_to_string(repl_nix_file.clone()).unwrap();
+
+        assert_eq!("{pkgs}: {\n  deps = [\n  ];\n}\n",
+                   contents);
+
+        drop(repl_nix_file);
+        dir.close().unwrap();
     }
 }

--- a/src/remover.rs
+++ b/src/remover.rs
@@ -17,8 +17,8 @@ pub fn remove_dep(
     let remove_start: usize = search_backwards_non_whitespace(text_start, contents);
     let remove_end: usize = range_to_remove.end().into();
 
-    let (before, _) = contents.split_at(remove_start);
-    let after = contents.chars().skip(remove_end).collect::<String>();
+    let (before, mid) = contents.split_at(remove_start);
+    let (_, after) = mid.split_at(remove_end + text_start - remove_start);
 
     Ok(format!("{}{}", before, after))
 }

--- a/src/remover.rs
+++ b/src/remover.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use rnix::{SyntaxNode, TextRange};
 
 pub fn remove_dep(
-    contents: &mut String,
+    contents: &str,
     deps_list: SyntaxNode,
     remove_dep_opt: Option<String>,
 ) -> Result<String> {
@@ -17,14 +17,13 @@ pub fn remove_dep(
     let remove_start: usize = search_backwards_non_whitespace(text_start, contents);
     let remove_end: usize = range_to_remove.end().into();
 
-    let new_contents = contents.split_off(remove_start);
-    let end_section = new_contents
+    let (before,_) = contents.split_at(remove_start);
+    let after = contents
         .chars()
-        .skip(remove_end - remove_start)
+        .skip(remove_end)
         .collect::<String>();
-    contents.push_str(&end_section);
 
-    Ok(contents.to_string())
+    Ok(format!("{}{}", before, after))
 }
 
 fn search_backwards_non_whitespace(start_pos: usize, contents: &str) -> usize {
@@ -95,7 +94,7 @@ mod remove_tests {
         let dep_to_remove = "pkgs.ncdu";
 
         let new_contents = remove_dep(
-            &mut contents.to_string(),
+            &contents,
             deps_list.node,
             Some(dep_to_remove.to_string()),
         );
@@ -114,7 +113,7 @@ mod remove_tests {
 
     #[test]
     fn test_regular_remove_dep() {
-        let mut contents = python_replit_nix();
+        let contents = python_replit_nix();
         let tree = rnix::Root::parse(&contents).syntax();
         let deps_list_res = verify_get(&tree, DepType::Regular);
         assert!(deps_list_res.is_ok());
@@ -124,7 +123,7 @@ mod remove_tests {
         let dep_to_remove = "pkgs.python38Full";
 
         let new_contents = remove_dep(
-            &mut contents,
+            &contents,
             deps_list.node,
             Some(dep_to_remove.to_string()),
         );
@@ -154,7 +153,7 @@ mod remove_tests {
 
     #[test]
     fn test_python_remove_dep() {
-        let mut contents = python_replit_nix();
+        let contents = python_replit_nix();
         let tree = rnix::Root::parse(&contents).syntax();
         let deps_list_res = verify_get(&tree, DepType::Python);
         assert!(deps_list_res.is_ok());
@@ -164,7 +163,7 @@ mod remove_tests {
         let dep_to_remove = "pkgs.glib";
 
         let new_contents = remove_dep(
-            &mut contents,
+            &contents,
             deps_list.node,
             Some(dep_to_remove.to_string()),
         );

--- a/src/remover.rs
+++ b/src/remover.rs
@@ -17,8 +17,8 @@ pub fn remove_dep(
     let remove_start: usize = search_backwards_non_whitespace(text_start, contents);
     let remove_end: usize = range_to_remove.end().into();
 
-    let (before, mid) = contents.split_at(remove_start);
-    let (_, after) = mid.split_at(remove_end + text_start - remove_start);
+    let (before, rest) = contents.split_at(remove_start);
+    let (_, after) = rest.split_at(remove_end - remove_start);
 
     Ok(format!("{}{}", before, after))
 }

--- a/src/remover.rs
+++ b/src/remover.rs
@@ -17,11 +17,8 @@ pub fn remove_dep(
     let remove_start: usize = search_backwards_non_whitespace(text_start, contents);
     let remove_end: usize = range_to_remove.end().into();
 
-    let (before,_) = contents.split_at(remove_start);
-    let after = contents
-        .chars()
-        .skip(remove_end)
-        .collect::<String>();
+    let (before, _) = contents.split_at(remove_start);
+    let after = contents.chars().skip(remove_end).collect::<String>();
 
     Ok(format!("{}{}", before, after))
 }
@@ -93,11 +90,7 @@ mod remove_tests {
 
         let dep_to_remove = "pkgs.ncdu";
 
-        let new_contents = remove_dep(
-            &contents,
-            deps_list.node,
-            Some(dep_to_remove.to_string()),
-        );
+        let new_contents = remove_dep(&contents, deps_list.node, Some(dep_to_remove.to_string()));
         assert!(new_contents.is_ok());
 
         let new_contents = new_contents.unwrap();
@@ -122,11 +115,7 @@ mod remove_tests {
 
         let dep_to_remove = "pkgs.python38Full";
 
-        let new_contents = remove_dep(
-            &contents,
-            deps_list.node,
-            Some(dep_to_remove.to_string()),
-        );
+        let new_contents = remove_dep(&contents, deps_list.node, Some(dep_to_remove.to_string()));
         assert!(new_contents.is_ok());
 
         let new_contents = new_contents.unwrap();
@@ -162,11 +151,7 @@ mod remove_tests {
 
         let dep_to_remove = "pkgs.glib";
 
-        let new_contents = remove_dep(
-            &contents,
-            deps_list.node,
-            Some(dep_to_remove.to_string()),
-        );
+        let new_contents = remove_dep(&contents, deps_list.node, Some(dep_to_remove.to_string()));
         assert!(new_contents.is_ok());
 
         let new_contents = new_contents.unwrap();


### PR DESCRIPTION
Why
===
* There was a bug in the remove flag that meant it did not change the file after calculating a remove.
* The problem was the contents were mutated and then when the comparison between new_contents and contents was made they were always the same: the new contents

What changed
===
* Add integration test reproducing this
* Stop allowing contents to be mutated and instead clone the contents when passing them to remove.

Test plan
===
* `cargo test` passes