### PR TITLE
fix double copy

### DIFF
--- a/nix-editor.nix
+++ b/nix-editor.nix
@@ -10,5 +10,8 @@ rustPlatform.buildRustPackage {
     lockFile = ./Cargo.lock;
   };
 
-  src = ./.;
+  src = builtins.path {
+    path = ./.;
+    name = "source";
+  };
 }


### PR DESCRIPTION
Why
===
* New lazy trees nix warns about double copies from using ./.

What changed
===
* Replace with recommended replacement
* Format nix with rfc format

Test plan
===
* `nix build` works